### PR TITLE
[IMP] New option 'odoo_repo_update' (default to True) to have more control on the repository checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ odoo_repo_type: git     # git or hg
 odoo_repo_url: https://github.com/odoo/odoo.git
 odoo_repo_dest: "{{ odoo_rootdir }}"
 odoo_repo_rev: 8.0
+odoo_repo_update: True  # Update the working copy or not. This option is
+                        # ignored on the first run (a checkout of the working
+                        # copy is always processed on the given revision)
+                        # WARNING: uncommited changes will be discarded!
 
 # Odoo parameters
 odoo_config_addons_path: "/home/{{ odoo_user }}/odoo/server/addons,/home/{{ odoo_user }}/odoo/server/openerp/addons"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,10 @@ odoo_repo_type: git     # git or hg
 odoo_repo_url: https://github.com/odoo/odoo.git
 odoo_repo_dest: "{{ odoo_rootdir }}"
 odoo_repo_rev: 8.0
+odoo_repo_update: True  # Update the working copy or not. This option is
+                        # ignored on the first run (a checkout of the working
+                        # copy is always processed on the given revision)
+                        # WARNING: uncommited changes will be discarded!
 
 # Configuration options
 odoo_config_addons_path: "/home/{{ odoo_user }}/odoo/server/addons,/home/{{ odoo_user }}/odoo/server/openerp/addons"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     - odoo
     - odoo_log
 
-- name: Project repository exists? (Mercurial)
+- name: Project repository already cloned?
   stat: path={{ odoo_repo_dest }}
   register: project_path
   tags:
@@ -48,8 +48,8 @@
   hg:   repo={{ odoo_repo_url }}
         dest={{ odoo_repo_dest }}
         revision={{ odoo_repo_rev }}
-        force=no
-  when: odoo_repo_type == 'hg' and project_path.stat.exists == False and odoo_repo_url
+  when: odoo_repo_type == 'hg' and odoo_repo_url
+        and (odoo_repo_update or (project_path.stat.exists == False))
   tags:
     - odoo
     - odoo_project
@@ -59,8 +59,8 @@
   git:  repo={{ odoo_repo_url }}
         dest={{ odoo_repo_dest }}
         version={{ odoo_repo_rev }}
-        update=no
-        force=no
+        update={{ project_path.stat.exists == False and 'yes'
+                  or (odoo_repo_update and 'yes' or 'no') }}
   when: odoo_repo_type == 'git' and odoo_repo_url
   tags:
     - odoo


### PR DESCRIPTION
Note: a checkout will always occured on the first playbook run, even with 'odoo_repo_update: False' (fix issue #8).