### PR TITLE
Missing sudo attribute in git/hg cloning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,6 +42,7 @@
     - odoo_project
 
 - name: Clone project repository (Mercurial)
+  sudo: yes
   sudo_user: "{{ odoo_user }}"
   hg:   repo={{ odoo_repo_url }}
         dest={{ odoo_repo_dest }}
@@ -52,6 +53,7 @@
     - odoo_project
 
 - name: Clone project repository (Git)
+  sudo: yes
   sudo_user: "{{ odoo_user }}"
   git:  repo={{ odoo_repo_url }}
         dest={{ odoo_repo_dest }}


### PR DESCRIPTION
Ansible seems to ignore  when  is not explicitly set to , which may cause the repository to be cloned as the user .