### PR TITLE
[IMP] Installation of the wkhtmltox tool.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ odoo_repo_update: True  # Update the working copy or not. This option is
                         # WARNING: uncommited changes will be discarded!
 odoo_repo_depth: 1      # Set to 0 to clone the full history (slower)
                         # (this option is not supported with hg)
+odoo_wkhtmltox_version: 0.12.2.1    # Download URLs available in the
+                                    # 'odoo_wkhtmltox_urls' variable
+                                    # (see 'vars/main.yml')
 
 # Configuration options
 odoo_config_addons_path:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
     - odoo
     - odoo_install
 
+- include: wkhtmltox.yml
+  tags:
+    - odoo
+    - odoo_wkhtmltox
+
 - include: config.yml
   tags:
     - odoo

--- a/tasks/wkhtmltox.yml
+++ b/tasks/wkhtmltox.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Detect Debian architecture (i386 or amd64)
+  set_fact: odoo_debian_arch={{ '64' in ansible_architecture and 'amd64' or 'i386' }}
+
+- name: Download wkhtmltox
+  get_url: url={{ item }}
+           dest={{ odoo_wkhtmltox_dest }}
+  with_items: odoo_wkhtmltox_urls
+  ignore_errors: True
+  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False
+
+# Use to detect that the package was downloaded.
+# We can not register the result of the previous task to check this as Ansible
+# will flag it as failed as soon as one URL fails (even if the download has
+# worked on a further URL)
+- name: Check wkhtmltox package
+  stat: path={{ odoo_wkhtmltox_dest }}
+  register: odoo_wkhtmltox_pkg
+
+- name: Install wkhtmltox dependencies
+  apt:  pkg={{ item }}
+  with_items: odoo_wkhtmltox_depends
+  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists
+
+- name: Install wkhtmltox
+  apt:  deb="/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb"
+  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -45,3 +45,23 @@ odoo_debian_packages:
 
 odoo_pypi_packages:
     - psycogreen
+
+odoo_wkhtmltox_urls:
+    - http://sourceforge.net/projects/wkhtmltopdf/files/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    - http://sourceforge.net/projects/wkhtmltopdf/files/archive/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+
+odoo_wkhtmltox_dest: "/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb"
+
+odoo_wkhtmltox_depends:     # Taken from the debian package
+    - fontconfig
+    - libfontconfig1
+    - libfreetype6
+    - libpng12-0
+    - zlib1g
+    - libjpeg-turbo8
+    - libssl1.0.0
+    - libx11-6
+    - libxext6
+    - libxrender1
+    - libstdc++6
+    - libc6


### PR DESCRIPTION
The option ``odoo_wkhtmltox_version`` allows to choose the version to install, and the ``odoo_wkhtmltox_urls`` variable contains a list of URLs on which the download will be attempted (fix #5).

As ``wkhtmltopdf`` is installed from upstream Debian packages, it only works from the ``0.12.1`` version.

@clonedagain : have you any feedback on this before a merge?