### PR TITLE
Install the ReportLab fonts for barcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ odoo_repo_depth: 1      # Set to 0 to clone the full history
 odoo_wkhtmltox_version: 0.12.1      # Download URLs available in the
                                     # 'odoo_wkhtmltox_urls' variable
                                     # (see 'vars/main.yml')
+odoo_reportlab_font_url: http://www.reportlab.com/ftp/pfbfer.zip
 
 # Tasks related to PostgreSQL
 odoo_postgresql_set_user: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ odoo_repo_depth: 1      # Set to 0 to clone the full history (slower)
 odoo_wkhtmltox_version: 0.12.1      # Download URLs available in the
                                     # 'odoo_wkhtmltox_urls' variable
                                     # (see 'vars/main.yml')
+odoo_reportlab_font_url: http://www.reportlab.com/ftp/pfbfer.zip
 
 # Tasks related to PostgreSQL
 odoo_postgresql_set_user: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,11 @@
     - odoo
     - odoo_wkhtmltox
 
+- include: reportlab.yml
+  tags:
+    - odoo
+    - odoo_reportlab
+
 - include: config.yml
   tags:
     - odoo

--- a/tasks/reportlab.yml
+++ b/tasks/reportlab.yml
@@ -1,0 +1,20 @@
+---
+# Download and install the barcode fonts from ReportLab
+- name: Download the ReportLab barcode fonts
+  get_url: url="{{ odoo_reportlab_font_url }}"
+           dest="/root/pfbfer.zip"
+
+- name: Create the font directory
+  file: path="/home/{{ odoo_user }}/fonts" state=directory
+
+- name: Install unzip
+  apt: name=unzip state=installed
+
+- name: Unzip the ReportLab fonts
+  unarchive: src="/root/pfbfer.zip"
+             dest="/home/{{ odoo_user }}/fonts"
+             owner={{ odoo_user }}
+             group={{ odoo_user }}
+             mode="u=rwX,go=rX"
+             copy=No
+             creates="/home/{{ odoo_user }}/fonts/_abi____.pfb"


### PR DESCRIPTION
Fixes https://github.com/osiell/ansible-odoo/issues/18
As per odoo/odoo#3234, we have to install a bunch of extra fonts for the barcodes to be printed on the standard reports.
The fonts must be downloaded from the upstream reportlab website directly.
We install the fonts to `/home/{{odoo_user}}/fonts` as suggested by @sebalix.