### PR TITLE
Changes to get Odoo 9.0 working on Ubuntu 14.04

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,8 +16,12 @@
   tags:
     - odoo_packages
 
+- stat: path=/usr/bin/node
+  register: node_executable
+
 - name: Add symlink '/usr/bin/node' for nodejs
   file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
+  when: node_executable.stat.exists == False
   tags:
     - odoo_packages
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,20 @@
   tags:
     - odoo_packages
 
+- name: Add symlink '/usr/bin/node' for nodejs
+  file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
+  tags:
+    - odoo_packages
+
+- name: Install less compiler for theme
+  npm:  name={{ item }}
+        global=yes
+  with_items:
+    - less
+    - less-plugin-clean-css
+  tags:
+    - odoo_packages
+
 - name: Install Odoo dependencies (PyPi)
   pip: name={{ item }}
   with_items: odoo_pypi_packages

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,8 @@ odoo_required_tools:
     - python-pip
 
 odoo_debian_packages:
+    - nodejs
+    - npm
     - python-dev
     - python-psycopg2
     - python-simplejson


### PR DESCRIPTION
- make sure npm & nodejs are installed; 
- add less & less-plugin-clean-css (globally)
- make a link from nodejs script to node script

This resolves #26 for me.