### PR TITLE
[IMP] Add the 'buildout' install type (anybox.recipe.odoo integration)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,19 @@ python: "2.7"
 
 env:
   # Odoo 8.0
-  - ODOO_VERSION=8.0 ANSIBLE_VERSION="1.9,<2.0"
-  - ODOO_VERSION=8.0 ANSIBLE_VERSION="2.0,<2.1"
-  - ODOO_VERSION=8.0 ANSIBLE_VERSION="2.1,<2.2"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="1.9,<2.0"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="1.9,<2.0"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="2.0,<2.1"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="2.0,<2.1"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="2.1,<2.2"
+  - ODOO_VERSION=8.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="2.1,<2.2"
   # Odoo 9.0
-  - ODOO_VERSION=9.0 ANSIBLE_VERSION="1.9,<2.0"
-  - ODOO_VERSION=9.0 ANSIBLE_VERSION="2.0,<2.1"
-  - ODOO_VERSION=9.0 ANSIBLE_VERSION="2.1,<2.2"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="1.9,<2.0"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="1.9,<2.0"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="2.0,<2.1"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="2.0,<2.1"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=standard ANSIBLE_VERSION="2.1,<2.2"
+  - ODOO_VERSION=9.0 ODOO_INSTALL_TYPE=buildout ANSIBLE_VERSION="2.1,<2.2"
 
 before_install:
   - sudo apt-get update -qq
@@ -23,23 +29,4 @@ install:
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
 script:
-  # Check the role/playbook's syntax.
-  - "ansible-playbook -i tests/inventory tests/test.yml --syntax-check"
-  # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -e \"odoo_version=$ODOO_VERSION\""
-  - sudo service odoo status
-  # Run the role/playbook again, checking to make sure it's idempotent.
-  - >
-    ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -e "odoo_version=$ODOO_VERSION"
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'IDEMPOTENCE TEST: OK' && exit 0)
-    || (echo 'IDEMPOTENCE TEST: FAILED' && exit 1)
-  - sudo service odoo status
-  # Run the role/playbook again but change the configuration, and check if the service restart
-  - >
-    ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -e "odoo_version=$ODOO_VERSION odoo_config_workers=4"
-    | grep -q 'changed=2.*failed=0'
-    && (echo 'RESTART TEST: OK' && exit 0)
-    || (echo 'RESTART TEST: FAILED' && exit 1)
-  - sudo service odoo status
-  - sleep 3 && wget http://localhost:8069
+  - ./tests/run.sh

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 Ansible role to install Odoo from a Git or Mercurial repository,
 and configure it.
 
+This role supports two types of installation:
+
+* **standard**: install the Odoo dependencies from APT repositories and the
+Odoo project from a Git/Hg repository. Odoo is configured with Ansible options
+(`odoo_config_*` ones).
+
+* **buildout**: build the Odoo project from a Git/Hg repository containing a
+Buildout configuration file based on the
+[anybox.recipe.odoo](https://pypi.python.org/pypi/anybox.recipe.odoo/) recipe.
+Odoo and its dependencies are then installed and executed inside a Python
+virtual environment. The configuration part is also managed by Buildout
+(`odoo_config_*` options are not used excepting the `odoo_config_db_*` ones
+for PostgreSQL related tasks).
+
 Minimum Ansible Version: 2.0
 
 ## Supported versions and systems
@@ -15,17 +29,16 @@ Minimum Ansible Version: 2.0
 | Debian 8      | yes | yes |
 | Ubuntu 12.04  | yes |  -  |
 | Ubuntu 14.04  | yes | yes |
+| Ubuntu 16.04  | yes | yes |
 
 ### Buildout (odoo_install_type: buildout)
 
-| System / Odoo | 8.0 | 9.0 |
-|---------------|-----|-----|
-| Debian 7      | yes | yes |
-| Debian 8      | yes | yes |
-| Ubuntu 12.04  | yes | yes |
-| Ubuntu 14.04  | yes | yes |
+You only need a Debian-based system, all the stuff is then handled by Buildout
+to run Odoo >= 8.0.
 
 ## Example (Playbook)
+
+### odoo_install_type: standard (default)
 
 Standard installation (assuming that PostgreSQL is installed and running on
 the same host):
@@ -33,7 +46,7 @@ the same host):
 ```yaml
 - name: Odoo
   hosts: odoo_server
-  sudo: yes
+  become: yes
   roles:
     - odoo
   vars:
@@ -41,13 +54,16 @@ the same host):
     - odoo_config_admin_passwd: SuPerPassWorD
 ```
 
+With the standard installation type you configure Odoo with the available
+`odoo_config_*` options.
+
 Standard installation but with PostgreSQL installed on a remote host (and
 available from your Ansible inventory):
 
 ```yaml
 - name: Odoo
   hosts: odoo_server
-  sudo: yes
+  become: yes
   roles:
     - odoo
   vars:
@@ -58,8 +74,8 @@ available from your Ansible inventory):
     - odoo_config_db_passwd: PaSsWoRd
 ```
 
-Installation from a personnal Git repository such as your repository looks
-like this:
+Standard installation from a personnal Git repository such as your repository
+looks like this:
 
 ```sh
 REPO/
@@ -74,7 +90,7 @@ Here we set some options required by the ``connector`` framework:
 ```yaml
 - name: Odoo
   hosts: odoo_server
-  sudo: yes
+  become: yes
   roles:
     - odoo
   vars:
@@ -96,102 +112,82 @@ Here we set some options required by the ``connector`` framework:
     odoo_config_workers: 8
 ```
 
-## Variables
+### odoo_install_type: buildout
+
+With a Buildout installation type, Odoo is installed and configured directly
+by Buildout:
 
 ```yaml
-odoo_service: odoo
-odoo_version: 8.0
-odoo_user: odoo
-odoo_user_passwd: odoo
-odoo_user_system: False
-odoo_logdir: "/var/log/{{ odoo_user }}"
-odoo_workdir: "/home/{{ odoo_user }}/odoo"
-odoo_rootdir: "/home/{{ odoo_user }}/odoo/server"
-odoo_init: True
-odoo_init_env: {}
-    #VAR1: value1
-    #VAR2: value2
-odoo_config_file: "/home/{{ odoo_user }}/{{ odoo_service }}.conf"
-odoo_force_config: True
-odoo_repo_type: git     # git or hg
-odoo_repo_url: https://github.com/odoo/odoo.git
-odoo_repo_dest: "{{ odoo_rootdir }}"
-odoo_repo_rev: "{{ odoo_version }}"
-odoo_repo_update: True  # Update the working copy or not. This option is
-                        # ignored on the first run (a checkout of the working
-                        # copy is always processed on the given revision)
-                        # WARNING: uncommited changes will be discarded!
-odoo_repo_depth: 1      # Set to 0 to clone the full history
-                        # (option not supported with hg repository)
-odoo_wkhtmltox_version: 0.12.1      # Download URLs available in the
-                                    # 'odoo_wkhtmltox_urls' variable
-                                    # (see 'vars/main.yml')
-odoo_reportlab_font_url: http://www.reportlab.com/ftp/pfbfer.zip
-
-# Tasks related to PostgreSQL
-odoo_postgresql_set_user: True
-odoo_postgresql_active_unaccent: True
-
-# Odoo parameters
-odoo_config_addons_path:
-    - "/home/{{ odoo_user }}/odoo/server/openerp/addons"
-    - "/home/{{ odoo_user }}/odoo/server/addons"
-odoo_config_admin_passwd: admin
-odoo_config_auto_reload: False
-odoo_config_csv_internal_sep: ','
-odoo_config_data_dir: "/home/{{ odoo_user }}/.local/share/Odoo"
-odoo_config_db_host: False
-odoo_config_db_host_user: "{{ ansible_ssh_user }}"
-odoo_config_db_maxconn: 64
-odoo_config_db_name: False
-odoo_config_db_passwd: False
-odoo_config_db_port: False
-odoo_config_db_template: template1
-odoo_config_db_user: odoo
-odoo_config_dbfilter: '.*'
-odoo_config_debug_mode: False
-odoo_config_pidfile: None
-odoo_config_proxy_mode: False
-odoo_config_email_from: False
-odoo_config_geoip_database: /usr/share/GeoIP/GeoLiteCity.dat
-odoo_config_limit_memory_hard: 805306368
-odoo_config_limit_memory_soft: 671088640
-odoo_config_limit_time_cpu: 60
-odoo_config_limit_time_real: 120
-odoo_config_list_db: True
-odoo_config_log_db: False
-odoo_config_log_level: info
-odoo_config_logfile: None
-odoo_config_logrotate: False
-odoo_config_longpolling_port: 8072
-odoo_config_osv_memory_age_limit: 1.0
-odoo_config_osv_memory_count_limit: False
-odoo_config_max_cron_threads: 2
-odoo_config_secure_cert_file: server.cert
-odoo_config_secure_pkey_file: server.pkey
-odoo_config_server_wide_modules: None
-odoo_config_smtp_password: False
-odoo_config_smtp_port: 25
-odoo_config_smtp_server: localhost
-odoo_config_smtp_ssl: False
-odoo_config_smtp_user: False
-odoo_config_syslog: False
-odoo_config_timezone: False
-odoo_config_translate_modules: ['all']
-odoo_config_unaccent: False
-odoo_config_without_demo: False
-odoo_config_workers: 0
-odoo_config_xmlrpc: True
-odoo_config_xmlrpc_interface: ''
-odoo_config_xmlrpc_port: 8069
-odoo_config_xmlrpcs: True
-odoo_config_xmlrpcs_interface: ''
-odoo_config_xmlrpcs_port: 8071
-# Custom configuration options
-odoo_config_custom: {}
-    #your_option1: value1
-    #your_option2: value2
-
-# Extra options
-odoo_user_sshkeys: False    # ../../path/to/public_keys/*
+- name: Odoo
+  hosts: odoo_server
+  become: yes
+  roles:
+    - odoo
+  vars:
+    - odoo_install_type: buildout
+    - odoo_version: 8.0
+    - odoo_repo_type: git
+    - odoo_repo_url: https://github.com/osiell/odoo-buildout-example.git
+    - odoo_repo_rev: "{{ odoo_version }}"
+    - odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
 ```
+
+The same but with PostgreSQL installed on a remote host (and available from
+your Ansible inventory):
+
+```yaml
+- name: Odoo
+  hosts: odoo_server
+  become: yes
+  roles:
+    - odoo
+  vars:
+    - odoo_install_type: buildout
+    - odoo_version: 8.0
+    - odoo_repo_type: git
+    - odoo_repo_url: https://github.com/osiell/odoo-buildout-example.git
+    - odoo_repo_rev: "{{ odoo_version }}"
+    - odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
+    - odoo_config_db_host: pg_server
+    - odoo_config_db_user: odoo
+    - odoo_config_db_passwd: PaSsWoRd
+```
+
+By default Ansible is looking for a `bootstrap.py` script and a `buildout.cfg`
+file at the root of the cloned repository to call Buildout, but you can change
+that to point to your own files. Assuming your repository looks like this:
+
+```sh
+REPO/
+├── addons              # custom modules
+├── bin
+│   └── bootstrap.py
+├── builtout.cfg
+├── builtout.dev.cfg
+├── builtout.prod.cfg
+└── builtout.test.cfg
+```
+
+We just set the relevant options to tell Ansible the files to use with the
+`odoo_buildout_*` options:
+
+```yaml
+- name: Odoo
+  hosts: odoo_server
+  become: yes
+  roles:
+    - odoo
+  vars:
+    - odoo_install_type: buildout
+    - odoo_version: 8.0
+    - odoo_repo_type: git
+    - odoo_repo_url: https://SERVER/REPO
+    - odoo_repo_rev: master
+    - odoo_repo_dest: "/home/{{ odoo_user }}/odoo"
+    - odoo_buildout_bootstrap_path: "/home/{{ odoo_user }}/odoo/bin/bootstrap.py"
+    - odoo_buildout_config_path: "/home/{{ odoo_user }}/odoo/buildout.prod.cfg"
+```
+
+## Variables
+
+See the [defaults/main.yml](defaults/main.yml) file.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,22 @@ Minimum Ansible Version: 2.0
 
 ## Supported versions and systems
 
+### Standard (odoo_install_type: standard)
+
 | System / Odoo | 8.0 | 9.0 |
 |---------------|-----|-----|
 | Debian 7      | yes |  -  |
 | Debian 8      | yes | yes |
 | Ubuntu 12.04  | yes |  -  |
+| Ubuntu 14.04  | yes | yes |
+
+### Buildout (odoo_install_type: buildout)
+
+| System / Odoo | 8.0 | 9.0 |
+|---------------|-----|-----|
+| Debian 7      | yes | yes |
+| Debian 8      | yes | yes |
+| Ubuntu 12.04  | yes | yes |
 | Ubuntu 14.04  | yes | yes |
 
 ## Example (Playbook)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,17 +12,6 @@ odoo_logdir: "/var/log/{{ odoo_user }}"
 odoo_workdir: "/home/{{ odoo_user }}/odoo"
 odoo_rootdir: "{{ odoo_install_type == 'buildout' and '/home/'+odoo_user+'/odoo/parts/odoo' or '/home/'+odoo_user+'/odoo/server' }}"
 
-# Standard installation options (odoo_install_type == 'standard')
-odoo_config_file: "/home/{{ odoo_user }}/{{ odoo_service }}.conf"
-odoo_force_config: True
-
-# Buildout installation options (odoo_install_type == 'buildout')
-odoo_buildout_venv_path: "{{ odoo_workdir }}/sandbox"
-odoo_buildout_bootstrap_path: "{{ odoo_workdir }}/bootstrap.py"
-odoo_buildout_bin_path: "{{ odoo_workdir }}/bin/buildout"
-odoo_buildout_config_path: "{{ odoo_workdir }}/buildout.cfg"
-odoo_buildout_odoo_bin_path: "{{ odoo_workdir }}/bin/start_odoo"
-
 # Project repository to deploy
 odoo_repo_type: git     # git or hg
 odoo_repo_url: "{{ odoo_install_type == 'buildout' and 'https://github.com/osiell/odoo-buildout-example.git' or 'https://github.com/odoo/odoo.git' }}"
@@ -46,7 +35,9 @@ odoo_postgresql_set_user: True
 odoo_postgresql_user_role_attr: CREATEDB,NOSUPERUSER
 odoo_postgresql_active_unaccent: True
 
-# Configuration options (odoo_install_type == 'standard')
+# Standard installation/configuration options (odoo_install_type == 'standard')
+odoo_config_file: "/home/{{ odoo_user }}/{{ odoo_service }}.conf"
+odoo_force_config: True
 odoo_config_addons_path:
     - "/home/{{ odoo_user }}/odoo/server/openerp/addons"
     - "/home/{{ odoo_user }}/odoo/server/addons"
@@ -105,6 +96,13 @@ odoo_config_xmlrpcs_port: 8071
 odoo_config_custom: {}
     #your_option1: value1
     #your_option2: value2
+
+# Buildout installation options (odoo_install_type == 'buildout')
+odoo_buildout_venv_path: "{{ odoo_workdir }}/sandbox"
+odoo_buildout_bootstrap_path: "{{ odoo_workdir }}/bootstrap.py"
+odoo_buildout_bin_path: "{{ odoo_workdir }}/bin/buildout"
+odoo_buildout_config_path: "{{ odoo_workdir }}/buildout.cfg"
+odoo_buildout_odoo_bin_path: "{{ odoo_workdir }}/bin/start_odoo"
 
 # Extra options
 odoo_user_sshkeys: False    # ../../path/to/public_keys/*

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,20 +1,32 @@
-odoo_service: odoo
+odoo_install_type: standard     # standard, buildout
 odoo_version: 8.0
+odoo_service: odoo
 odoo_user: odoo
 odoo_user_passwd: odoo
 odoo_user_system: False
-odoo_logdir: "/var/log/{{ odoo_user }}"
-odoo_workdir: "/home/{{ odoo_user }}/odoo"
-odoo_rootdir: "/home/{{ odoo_user }}/odoo/server"
 odoo_init: True
 odoo_init_env: {}
     #VAR1: value1
     #VAR2: value2
+odoo_logdir: "/var/log/{{ odoo_user }}"
+odoo_workdir: "/home/{{ odoo_user }}/odoo"
+odoo_rootdir: "{{ odoo_install_type == 'buildout' and '/home/'+odoo_user+'/odoo/parts/odoo' or '/home/'+odoo_user+'/odoo/server' }}"
+
+# Standard installation options (odoo_install_type == 'standard')
 odoo_config_file: "/home/{{ odoo_user }}/{{ odoo_service }}.conf"
 odoo_force_config: True
+
+# Buildout installation options (odoo_install_type == 'buildout')
+odoo_buildout_venv_path: "{{ odoo_workdir }}/sandbox"
+odoo_buildout_bootstrap_path: "{{ odoo_workdir }}/bootstrap.py"
+odoo_buildout_bin_path: "{{ odoo_workdir }}/bin/buildout"
+odoo_buildout_config_path: "{{ odoo_workdir }}/buildout.cfg"
+odoo_buildout_odoo_bin_path: "{{ odoo_workdir }}/bin/start_odoo"
+
+# Project repository to deploy
 odoo_repo_type: git     # git or hg
-odoo_repo_url: https://github.com/odoo/odoo.git
-odoo_repo_dest: "{{ odoo_rootdir }}"
+odoo_repo_url: "{{ odoo_install_type == 'buildout' and 'https://github.com/osiell/odoo-buildout-example.git' or 'https://github.com/odoo/odoo.git' }}"
+odoo_repo_dest: "{{ odoo_install_type == 'buildout' and odoo_workdir or odoo_rootdir }}"
 odoo_repo_rev: "{{ odoo_version }}"
 odoo_repo_update: True  # Update the working copy or not. This option is
                         # ignored on the first run (a checkout of the working
@@ -22,6 +34,8 @@ odoo_repo_update: True  # Update the working copy or not. This option is
                         # WARNING: uncommited changes will be discarded!
 odoo_repo_depth: 1      # Set to 0 to clone the full history (slower)
                         # (this option is not supported with hg)
+
+# Third party programs options
 odoo_wkhtmltox_version: 0.12.1      # Download URLs available in the
                                     # 'odoo_wkhtmltox_urls' variable
                                     # (see 'vars/main.yml')
@@ -32,7 +46,7 @@ odoo_postgresql_set_user: True
 odoo_postgresql_user_role_attr: CREATEDB,NOSUPERUSER
 odoo_postgresql_active_unaccent: True
 
-# Configuration options
+# Configuration options (odoo_install_type == 'standard')
 odoo_config_addons_path:
     - "/home/{{ odoo_user }}/odoo/server/openerp/addons"
     - "/home/{{ odoo_user }}/odoo/server/addons"

--- a/files/bootstrap.py
+++ b/files/bootstrap.py
@@ -1,0 +1,210 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
+
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --buildout-version, "
+                        "the bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
+
+options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
+
+######################################################################
+# load/install setuptools
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+ez = {}
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
+cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+requirement = 'zc.buildout'
+version = options.buildout_version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
+ws.require(requirement)
+import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
+shutil.rmtree(tmpeggs)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
       versions:
         - precise
         - trusty
+        - xenial
   categories:
     - web
 dependencies: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,27 +8,6 @@
   tags:
     - odoo_required_tools
 
-- name: Install Odoo dependencies
-  apt:  pkg={{ item }}
-        state=installed
-        update_cache=yes
-  with_items: "{{ odoo_debian_packages }}"
-  tags:
-    - odoo_packages
-
-- name: Install Odoo dependencies (PyPi)
-  pip: name={{ item }}
-  with_items: "{{ odoo_pypi_packages }}"
-  tags:
-    - odoo_packages
-
-- name: Install Odoo dependencies (npm)
-  include: install_npm.yml
-  when: (odoo_version | int) >= 9
-  tags:
-    - odoo
-    - odoo_packages
-
 - name: Add Odoo system user
   user: name={{ odoo_user }} shell=/bin/bash
         password={{ odoo_user_passwd }} update_password=on_create
@@ -73,3 +52,27 @@
   notify: Restart Odoo
   tags:
     - odoo_project
+
+- name: Standard installation
+  include: install_standard.yml
+  when: odoo_install_type == 'standard'
+  tags:
+    - odoo_install_type_standard
+
+- name: Buildout installation
+  include: install_buildout.yml
+  when: odoo_install_type == 'buildout'
+  tags:
+    - odoo_install_type_buildout
+
+- name: Install NPM packages
+  include: install_npm.yml
+  when: (odoo_version | int) >= 9
+  tags:
+    - odoo
+    - odoo_packages
+
+- include: install_extra.yml
+  when: odoo_user_sshkeys is defined and odoo_user_sshkeys
+  tags:
+    - odoo_install_extra

--- a/tasks/install_buildout.yml
+++ b/tasks/install_buildout.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Install build dependencies
+  apt:  pkg={{ item }}
+        state=installed
+        update_cache=yes
+  with_items: "{{ odoo_buildout_build_dependencies }}"
+
+- name: Prepare the Python virtual environment
+  become: yes
+  become_user: "{{ odoo_user }}"
+  shell: "{{ odoo_buildout_venv_cmd }}"
+  args:
+    creates: "{{ odoo_buildout_venv_path }}"
+
+- name: Copy the bootstrap.py script
+  copy: src=bootstrap.py dest={{ odoo_buildout_bootstrap_path }}
+        owner={{ odoo_user }} group={{ odoo_user }} force=no
+
+- name: Install buildout (run the bootstrap.py script)
+  become: yes
+  become_user: "{{ odoo_user }}"
+  command: "{{ odoo_buildout_venv_path }}/bin/python {{ odoo_buildout_bootstrap_path }} -c {{ odoo_buildout_config_path }}"
+  args:
+    creates: "{{ odoo_buildout_bin_path }}"
+
+- name: Run buildout
+  become: yes
+  become_user: "{{ odoo_user }}"
+  command: "{{ odoo_buildout_bin_path }} -c {{ odoo_buildout_config_path }}"
+  changed_when: False
+
+- name: Generate Odoo init script
+  template: src=odoo-buildout.init dest=/etc/init.d/{{ odoo_service }}
+        owner=root group=root mode=0755
+        force=yes
+        backup=yes
+  when: odoo_init == True
+  notify: Restart Odoo

--- a/tasks/install_npm.yml
+++ b/tasks/install_npm.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Install npm
+  apt:  pkg=npm
+        state=installed
+        update_cache=yes
+
 - name: Check that '/usr/bin/nodejs' exists
   stat: path=/usr/bin/nodejs
   register: nodejs_executable

--- a/tasks/install_npm.yml
+++ b/tasks/install_npm.yml
@@ -21,4 +21,4 @@
   npm:  name={{ item.name }}
         version={{ item.version }}
         global=yes
-  with_items: odoo_npm_packages
+  with_items: "{{ odoo_npm_packages | default([]) }}"

--- a/tasks/install_standard.yml
+++ b/tasks/install_standard.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Install Odoo dependencies
+  apt:  pkg={{ item }}
+        state=installed
+        update_cache=yes
+  with_items: "{{ odoo_debian_packages }}"
+  tags:
+    - odoo_packages
+
+- name: Install Odoo dependencies (PyPi)
+  pip: name={{ item }}
+  with_items: "{{ odoo_pypi_packages }}"
+  tags:
+    - odoo_packages
+
+- include: config.yml
+  tags:
+    - odoo_config
+
+- name: Generate Odoo init script
+  template: src=odoo-{{ odoo_version }}.init dest=/etc/init.d/{{ odoo_service }}
+        owner=root group=root mode=0755
+        force={{ odoo_force_config and 'yes' or 'no' }}
+        backup=yes
+  when: odoo_init == True
+  notify: Restart Odoo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,13 +20,6 @@
     - odoo
     - odoo_install
 
-- include: install_extra.yml
-  when: odoo_user_sshkeys is defined and odoo_user_sshkeys
-  tags:
-    - odoo
-    - odoo_install
-    - odoo_install_extra
-
 - include: wkhtmltox.yml
   tags:
     - odoo
@@ -36,11 +29,6 @@
   tags:
     - odoo
     - odoo_reportlab
-
-- include: config.yml
-  tags:
-    - odoo
-    - odoo_config
 
 - include: postgresql_local.yml
   when: odoo_config_db_host in [False, 'localhost', '127.0.0.1']

--- a/tasks/postgresql_local.yml
+++ b/tasks/postgresql_local.yml
@@ -17,5 +17,4 @@
   become: yes
   become_user: postgres
   postgresql_ext: name=unaccent db=template1
-  when: odoo_config_unaccent
-        and odoo_postgresql_active_unaccent
+  when: odoo_postgresql_active_unaccent

--- a/tasks/postgresql_remote.yml
+++ b/tasks/postgresql_remote.yml
@@ -23,5 +23,4 @@
   become: yes
   become_user: postgres
   postgresql_ext: name=unaccent db=template1
-  when: odoo_config_unaccent
-        and odoo_postgresql_active_unaccent
+  when: odoo_postgresql_active_unaccent

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Generate Odoo init script
-  template: src=odoo-{{ odoo_version }}.init dest=/etc/init.d/{{ odoo_service }}
-        owner=root group=root mode=0755
-        force={{ odoo_force_config and 'yes' or 'no' }}
-        backup=yes
-
 - name: Enable Odoo service
   service: name={{ odoo_service }} enabled=yes state=started
   when: odoo_init == True

--- a/templates/odoo-buildout.init
+++ b/templates/odoo-buildout.init
@@ -1,0 +1,81 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          {{ odoo_service }}
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Should-Start:      $network
+# Should-Stop:       $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start odoo daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+## more info: http://wiki.debian.org/LSBInitScripts
+
+. /lib/lsb/init-functions
+
+PATH=/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin
+WORKDIR={{ odoo_workdir }}
+DAEMON={{ odoo_buildout_odoo_bin_path }}
+NAME={{ odoo_service }}
+DESC={{ odoo_service }}
+LOGFILE={{ odoo_logdir }}/{{ odoo_service }}.log
+PIDFILE=/var/run/${NAME}.pid
+USER={{ odoo_user }}
+export LOGNAME=$USER
+{% if odoo_init_env %}
+# Custom environment variables
+{% for name, value in odoo_init_env.iteritems() %}
+export {{ name }}={{ value }}
+{% endfor %}
+{% endif %}
+
+test -x $DAEMON || exit 0
+set -e
+
+function _start() {
+    start-stop-daemon --chdir=${WORKDIR} --start --quiet --pidfile $PIDFILE --chuid $USER:$USER --background --make-pidfile --exec $DAEMON -- --logfile $LOGFILE
+}
+
+function _stop() {
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE --oknodo --retry 3
+    rm -f $PIDFILE
+}
+
+function _status() {
+    start-stop-daemon --status --quiet --pidfile $PIDFILE
+    return $?
+}
+
+
+case "$1" in
+        start)
+                echo -n "Starting $DESC: "
+                _start
+                echo "ok"
+                ;;
+        stop)
+                echo -n "Stopping $DESC: "
+                _stop
+                echo "ok"
+                ;;
+        restart|force-reload)
+                echo -n "Restarting $DESC: "
+                _stop
+                sleep 1
+                _start
+                echo "ok"
+                ;;
+        status)
+                echo -n "Status of $DESC: "
+                _status && echo "running" || echo "stopped"
+                ;;
+        *)
+                N=/etc/init.d/$NAME
+                echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+                exit 1
+                ;;
+esac
+
+exit 0
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Check the role/playbook's syntax.
+ansible-playbook -i tests/inventory tests/test_$ODOO_INSTALL_TYPE.yml --syntax-check || exit 1
+# Run the role/playbook with ansible-playbook.
+ansible-playbook -i tests/inventory tests/test_$ODOO_INSTALL_TYPE.yml --connection=local --sudo -e "odoo_version=$ODOO_VERSION" || exit 1
+sudo service odoo-$ODOO_INSTALL_TYPE status || exit 1
+# Run the role/playbook again, checking to make sure it's idempotent.
+output_log=$ODOO_VERSION_$ODOO_INSTALL_TYPE.log
+ansible-playbook -i tests/inventory tests/test_${ODOO_INSTALL_TYPE}.yml --connection=local --sudo -e "odoo_version=$ODOO_VERSION" -v > $output_log || exit 1
+grep -q 'changed=0.*failed=0' $output_log \
+    && (echo 'IDEMPOTENCE TEST: OK' && exit 0) \
+    || (echo 'IDEMPOTENCE TEST: FAILED' && cat $output_log && exit 1) || exit 1
+sudo service odoo-$ODOO_INSTALL_TYPE status || exit 1
+# Run the role/playbook again but change the configuration, and check if the service restart
+ansible-playbook -i tests/inventory tests/test_${ODOO_INSTALL_TYPE}_changed.yml --connection=local --sudo -e "odoo_version=$ODOO_VERSION" -v > $output_log || exit 1
+grep -q 'changed=2.*failed=0' $output_log \
+    && (echo 'RESTART TEST: OK' && exit 0) \
+    || (echo 'RESTART TEST: FAILED' && cat $output_log && exit 1) || exit 1
+sudo service odoo-$ODOO_INSTALL_TYPE status || exit 1
+sleep 3 && wget http://localhost:8069  | exit 1
+sudo service odoo-$ODOO_INSTALL_TYPE stop  || exit 1
+# Clean up
+sudo rm -rf /home/odoo/odoo

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,0 @@
----
-
-- hosts: localhost
-  become: yes
-  roles:
-    - ansible-odoo

--- a/tests/test_buildout.yml
+++ b/tests/test_buildout.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible-odoo
+  vars:
+    odoo_install_type: buildout
+    odoo_service: odoo-buildout

--- a/tests/test_buildout_changed.yml
+++ b/tests/test_buildout_changed.yml
@@ -1,0 +1,11 @@
+---
+
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible-odoo
+  vars:
+    odoo_install_type: buildout
+    odoo_service: odoo-buildout
+    odoo_init_env:
+        CHANGED_TEST: 1

--- a/tests/test_standard.yml
+++ b/tests/test_standard.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible-odoo
+  vars:
+    odoo_install_type: standard
+    odoo_service: odoo-standard

--- a/tests/test_standard_changed.yml
+++ b/tests/test_standard_changed.yml
@@ -1,0 +1,11 @@
+---
+
+- hosts: localhost
+  become: yes
+  roles:
+    - ansible-odoo
+  vars:
+    odoo_install_type: standard
+    odoo_service: odoo-standard
+    odoo_init_env:
+        CHANGED_TEST: 1

--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -1,5 +1,7 @@
 ---
 
+odoo_buildout_venv_cmd: "virtualenv {{ odoo_buildout_venv_path }} && {{ odoo_buildout_venv_path }}/bin/python -c \"import setuptools\" && {{ odoo_buildout_venv_path }}/bin/pip uninstall setuptools -y"
+
 odoo_wkhtmltox_depends_dist:
     - libjpeg8
 

--- a/vars/Odoo-9.yml
+++ b/vars/Odoo-9.yml
@@ -36,7 +36,6 @@ odoo_debian_packages:
     - python-passlib
     - python-babel
     - python-gevent
-    - npm
 
 odoo_npm_packages:
     - name: less

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,9 +5,22 @@ odoo_required_tools:
     - git
     - mercurial
     - python-pip
+    - python-psycopg2
 
 odoo_pypi_packages:
     - psycogreen
+
+odoo_buildout_build_dependencies:
+    - python-virtualenv
+    - build-essential
+    - python-dev
+    - libxml2-dev
+    - libxslt1-dev
+    - libpq-dev
+    - libldap2-dev
+    - libsasl2-dev
+
+odoo_buildout_venv_cmd: "virtualenv --no-setuptools {{ odoo_buildout_venv_path }}"
 
 odoo_wkhtmltox_depends_common:
     - fontconfig


### PR DESCRIPTION
New option `odoo_install_type` which takes the value `standard` (default) or `buildout`.

The following options are also available to tune the `buildout` installation:
```yaml
odoo_buildout_venv_path: "{{ odoo_workdir }}/sandbox"
odoo_buildout_bootstrap_path: "{{ odoo_workdir }}/bootstrap.py"
odoo_buildout_bin_path: "{{ odoo_workdir }}/bin/buildout"
odoo_buildout_config_path: "{{ odoo_workdir }}/buildout.cfg"
odoo_buildout_odoo_bin_path: "{{ odoo_workdir }}/bin/start_odoo"
```