### PR TITLE
[FIX] buildout - Pillow requires some development libraries to support some image formats

### DIFF
--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -13,6 +13,9 @@ odoo_buildout_build_dependencies:
     - libsasl2-dev
     - libopenjpeg-dev
     - libjpeg8-dev
+    - libtiff5-dev
+    - libfreetype6-dev
+    - liblcms2-dev
 
 odoo_wkhtmltox_depends_dist:
     - libjpeg8

--- a/vars/Ubuntu-12.yml
+++ b/vars/Ubuntu-12.yml
@@ -9,14 +9,13 @@ odoo_buildout_build_dependencies:
     - libpq-dev
     - libldap2-dev
     - libsasl2-dev
-    - libopenjp2-7-dev
-    - libjpeg62-turbo-dev
+    - libopenjpeg-dev
+    - libjpeg-turbo8-dev
     - libtiff5-dev
     - libfreetype6-dev
     - liblcms2-dev
-    - libwebp-dev
 
 odoo_wkhtmltox_depends_dist:
-    - libjpeg62-turbo
+    - libjpeg-turbo8
 
 odoo_wkhtmltox_depends: "{{ odoo_wkhtmltox_depends_common + odoo_wkhtmltox_depends_dist }}"

--- a/vars/Ubuntu-14.yml
+++ b/vars/Ubuntu-14.yml
@@ -9,14 +9,14 @@ odoo_buildout_build_dependencies:
     - libpq-dev
     - libldap2-dev
     - libsasl2-dev
-    - libopenjp2-7-dev
-    - libjpeg62-turbo-dev
+    - libopenjpeg-dev
+    - libjpeg-turbo8-dev
     - libtiff5-dev
     - libfreetype6-dev
     - liblcms2-dev
     - libwebp-dev
 
 odoo_wkhtmltox_depends_dist:
-    - libjpeg62-turbo
+    - libjpeg-turbo8
 
 odoo_wkhtmltox_depends: "{{ odoo_wkhtmltox_depends_common + odoo_wkhtmltox_depends_dist }}"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -9,8 +9,12 @@ odoo_buildout_build_dependencies:
     - libpq-dev
     - libldap2-dev
     - libsasl2-dev
-    - libopenjpeg-dev
+    - libopenjp2-7-dev
     - libjpeg-turbo8-dev
+    - libtiff5-dev
+    - libfreetype6-dev
+    - liblcms2-dev
+    - libwebp-dev
 
 odoo_wkhtmltox_depends_dist:
     - libjpeg-turbo8


### PR DESCRIPTION
These packages differs between distributions and releases. (#39 improvements)