### PR TITLE
Delegate to the inventory host

### DIFF
--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -2,7 +2,7 @@
 
 - name: Delegate PostgreSQL tasks to the relevant host
   set_fact:
-    odoo_postgresql_delegate_to: "{{ odoo_config_db_host if ((odoo_config_db_host|bool) != False) else ansible_host }}"
+    odoo_postgresql_delegate_to: "{{ odoo_config_db_host if ((odoo_config_db_host|bool) != False) else inventory_hostname }}"
     odoo_postgresql_remote_user: "{{ odoo_config_db_host_user if ((odoo_config_db_host|bool) != False) else ansible_user }}"
 
 - block:


### PR DESCRIPTION
Delegating to the current ansible_host works only if the host matches the inventory name and default ssh port is used. Using the inventory name instead will let Ansible do the translation.
For example, when using Vagrant we'll have ansible_host=127.0.0.1 and use a random ssh port, wherease ansible_host works as expected.