### PR TITLE
Add Xenial specifics

### DIFF
--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,0 +1,29 @@
+---
+
+odoo_buildout_build_dependencies:
+    - python-virtualenv
+    - build-essential
+    - python-dev
+    - libxml2-dev
+    - libxslt1-dev
+    - libpq-dev
+    - libldap2-dev
+    - libsasl2-dev
+    - libopenjp2-7-dev
+    - libjpeg-turbo8-dev
+    - libtiff5-dev
+    - libfreetype6-dev
+    - liblcms2-dev
+    - libwebp-dev
+
+odoo_wkhtmltox_depends_dist:
+    - libjpeg-turbo8
+
+odoo_wkhtmltox_depends: "{{ odoo_wkhtmltox_depends_common + odoo_wkhtmltox_depends_dist }}"
+
+# Try Trusty's package if no Xenial one is found
+odoo_wkhtmltox_urls:
+    - http://download.gna.org/wkhtmltopdf/0.12/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    - http://download.gna.org/wkhtmltopdf/0.12/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-trusty-{{ odoo_debian_arch }}.deb
+    - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+


### PR DESCRIPTION
There's not Xenial package for wkhtmltox 0.12.1, but the trusty one should work just fine
Fixes #45