### PR TITLE
[FIX] .travis.yml: Install an old release (2.0) of LXD from trusty-backports

### DIFF
--- a/tests/travis_lxd/create_container.sh
+++ b/tests/travis_lxd/create_container.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 HERE=$(dirname $(readlink -m $0))
+CT_DIR="/var/lib/lxd/containers/$1"
 # Spawn a LXD container
-lxc init ${IMAGE} $1
+lxc init ${IMAGE} $1 -c security.privileged=true
 lxc config set $1 raw.lxc "lxc.aa_allow_incomplete=1"
 if [[ "$IMAGE" == 'images:debian/jessie' ]]; then
     $HERE/fix_debian_jessie.sh $1;
@@ -12,6 +13,6 @@ lxc config set $1 environment.ODOO_VERSION $ODOO_VERSION
 lxc config set $1 environment.ODOO_INSTALL_TYPE $ODOO_INSTALL_TYPE
 lxc config set $1 environment.ANSIBLE_VERSION $ANSIBLE_VERSION
 # Copy the project files into the container
-lxc file push -r -p $HERE/../.. $1/opt/
+cp -av $HERE/../.. $CT_DIR/rootfs/opt/ansible-odoo
 # Install the test environment
 lxc exec $1 -- sh -c "/opt/ansible-odoo/tests/install_test_env.sh"

--- a/tests/travis_lxd/fix_debian_jessie.sh
+++ b/tests/travis_lxd/fix_debian_jessie.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # This script fix the Debian Jessie container by replacing systemd by SysV
 #
-CT_DIR="/var/lib/lxd/storage-pools/default/containers/$1"
+CT_DIR="/var/lib/lxd/containers/$1"
 ROOTFS="$CT_DIR/rootfs"
 UID_GID=$(ls -n $CT_DIR | grep rootfs | cut -d ' ' -f "3-4")
 CT_UID=$(echo $UID_GID | cut -d ' ' -f1)
 CT_GID=$(echo $UID_GID | cut -d ' ' -f2)
 CT_UID_GID="$CT_UID:$CT_GID"
-BRIDGE_IP=$(lxc network show testbr0 | grep ipv4.address | cut -d' ' -f4 | cut -d'/' -f1)
+BRIDGE_IP=$(/sbin/ifconfig lxdbr0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
 # Configure the network of the container
 echo -e "nameserver $BRIDGE_IP\nsearch lxd" > $ROOTFS/etc/resolv.conf
 cat $ROOTFS/etc/resolv.conf

--- a/tests/travis_lxd/install.sh
+++ b/tests/travis_lxd/install.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+HERE=$(dirname $(readlink -m $0))
 # Install and configure LXD on Travis-CI
-add-apt-repository -y ppa:ubuntu-lxc/lxd-stable;
+debconf-set-selections $HERE/lxd-debconf
+echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' > /etc/apt/sources.list.d/backports.list
 apt-get -qq update;
-apt-get -y install lxd;
+apt-get -y install -t trusty-backports ca-certificates lxd;
 lxd init --auto
 usermod -a -G lxd travis
-lxc network create testbr0
-lxc network attach-profile testbr0 default eth0
-lxc network show testbr0

--- a/tests/travis_lxd/lxd-debconf
+++ b/tests/travis_lxd/lxd-debconf
@@ -1,0 +1,22 @@
+lxd	lxd/bridge-ipv4-address	string	10.224.136.1
+lxd	lxd/bridge-ipv4-dhcp-leases	string	252
+lxd	lxd/use-existing-bridge	boolean	false
+lxd	lxd/bridge-ipv6-netmask	string	
+lxd	lxd/bridge-ipv6	boolean	false
+lxd	lxd/setup-bridge	boolean	true
+lxd	lxd/bridge-ipv4-netmask	string	24
+lxd	lxd/bridge-ipv4	boolean	true
+lxd	lxd/bridge-ipv6-address	string	
+lxd	lxd/update-profile	boolean	true
+lxd	lxd/bridge-name	string	lxdbr0
+lxd	lxd/bridge-empty-error	note	
+# lxcbr0 is being replaced by lxdbr0
+lxd	lxd/bridge-upgrade-warning	note	
+lxd	lxd/bridge-ipv6-nat	boolean	false
+lxd	lxd/bridge-random-warning	note	
+lxd	lxd/bridge-domain	string	lxd
+lxd	lxd/bridge-dnsmasq	string	
+lxd	lxd/bridge-http-proxy	boolean	false
+lxd	lxd/bridge-ipv4-nat	boolean	true
+lxd	lxd/bridge-ipv4-dhcp-last	string	10.224.136.254
+lxd	lxd/bridge-ipv4-dhcp-first	string	10.224.136.2


### PR DESCRIPTION
Official LXD PPA deprecated/removed and snap does not work on Trusty.

Some LXD features are missing in 2.0:
- ``lxc network``: the bridge configuration is now done through ``debconf``
- ``lxc file``: the `ansible-odoo` project is now copied directly inside the `rootfs` of the container (hackish but functional)