### PR TITLE
[IMP] wkhtmltox: handle the installation of wkhtmltox 0.12.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,6 @@ odoo_repo_depth: 1      # Set to 0 to clone the full history (slower)
                         # (this option is not supported with hg)
 
 # Third party programs options
-odoo_wkhtmltox_version: 0.12.1      # Download URLs available in the
-                                    # 'odoo_wkhtmltox_urls' variable
-                                    # (see 'vars/main.yml')
 odoo_reportlab_font_url: http://www.reportlab.com/ftp/pfbfer.zip
 
 # Tasks related to PostgreSQL

--- a/tasks/wkhtmltox.yml
+++ b/tasks/wkhtmltox.yml
@@ -23,7 +23,17 @@
   with_items: "{{ odoo_wkhtmltox_depends }}"
   when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists
 
-- name: Install wkhtmltox
-  apt:  deb="/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb"
-        force=yes
-  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists
+- name: Install wkhtmltox (Debian package)
+  apt:
+    deb: "{{ odoo_wkhtmltox_dest }}"
+    force: yes
+  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists and odoo_wkhtmltox_pkg.stat.mimetype in ['application/x-debian-package', 'application/vnd.debian.binary-package']
+
+- name: Install wkhtmltox (generic package)
+  unarchive:
+    remote_src: yes
+    src: "{{ odoo_wkhtmltox_dest }}"
+    dest: /usr/local
+    extra_opts: "--strip-components=1"
+    creates: /usr/local/bin/wkhtmltopdf
+  when: odoo_wkhtmltox_version is defined and odoo_wkhtmltox_version != False and odoo_wkhtmltox_pkg.stat.exists and odoo_wkhtmltox_pkg.stat.mimetype == 'application/x-xz'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -39,3 +39,6 @@ echo "== CHECK THE SERVICE STATUS =="
 sudo -E service odoo-$ODOO_INSTALL_TYPE status || exit 1
 sleep 3 && if ! wget http://localhost:8069; then tail -n 100 /var/log/odoo/*.log && exit 1; fi
 sudo -E service odoo-$ODOO_INSTALL_TYPE stop || exit 1
+
+echo "== CHECK WKHTMLTOPDF =="
+wkhtmltopdf --version

--- a/vars/Debian-8_Odoo-10.yml
+++ b/vars/Debian-8_Odoo-10.yml
@@ -91,6 +91,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1.2
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Debian-8_Odoo-8.yml
+++ b/vars/Debian-8_Odoo-8.yml
@@ -79,6 +79,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1.2
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Debian-8_Odoo-9.yml
+++ b/vars/Debian-8_Odoo-9.yml
@@ -86,6 +86,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1.2
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Debian-9_Odoo-10.yml
+++ b/vars/Debian-9_Odoo-10.yml
@@ -93,16 +93,14 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
     - libfreetype6
-    - libpng12-0
     - zlib1g
-    - libssl1.0.0
     - libx11-6
     - libxext6
     - libxrender1
-    - libstdc++6
-    - libc6
     - libjpeg62-turbo

--- a/vars/Debian-9_Odoo-11.yml
+++ b/vars/Debian-9_Odoo-11.yml
@@ -90,16 +90,14 @@ odoo_buildout_build_dependencies:
 odoo_buildout_venv_cmd: "python3 -m virtualenv --no-setuptools --python=python3 {{ odoo_buildout_venv_path }}"
 odoo_pip_venv_cmd: "python3 -m virtualenv --python=python3 {{ odoo_pip_venv_path }}"
 
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
     - libfreetype6
-    - libpng12-0
     - zlib1g
-    - libssl1.0.0
     - libx11-6
     - libxext6
     - libxrender1
-    - libstdc++6
-    - libc6
     - libjpeg62-turbo

--- a/vars/Debian-9_Odoo-8.yml
+++ b/vars/Debian-9_Odoo-8.yml
@@ -80,16 +80,14 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
     - libfreetype6
-    - libpng12-0
     - zlib1g
-    - libssl1.0.0
     - libx11-6
     - libxext6
     - libxrender1
-    - libstdc++6
-    - libc6
     - libjpeg62-turbo

--- a/vars/Debian-9_Odoo-9.yml
+++ b/vars/Debian-9_Odoo-9.yml
@@ -89,16 +89,14 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
     - libfreetype6
-    - libpng12-0
     - zlib1g
-    - libssl1.0.0
     - libx11-6
     - libxext6
     - libxrender1
-    - libstdc++6
-    - libc6
     - libjpeg62-turbo

--- a/vars/Ubuntu-14_Odoo-10.yml
+++ b/vars/Ubuntu-14_Odoo-10.yml
@@ -91,6 +91,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Ubuntu-14_Odoo-8.yml
+++ b/vars/Ubuntu-14_Odoo-8.yml
@@ -76,6 +76,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Ubuntu-14_Odoo-9.yml
+++ b/vars/Ubuntu-14_Odoo-9.yml
@@ -86,6 +86,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1

--- a/vars/Ubuntu-16_Odoo-10.yml
+++ b/vars/Ubuntu-16_Odoo-10.yml
@@ -105,8 +105,13 @@ odoo_wkhtmltox_depends:
     - libc6
     - libjpeg-turbo8
 
+odoo_wkhtmltox_version: 0.12.1
+
 # Try Trusty's package if Xenial one is not found
 odoo_wkhtmltox_urls:
+    # Debian packages
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-trusty-{{ odoo_debian_arch }}.deb
     - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    # generic tar.gz packages
+    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz

--- a/vars/Ubuntu-16_Odoo-11.yml
+++ b/vars/Ubuntu-16_Odoo-11.yml
@@ -95,25 +95,21 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_buildout_venv_cmd: "virtualenv --no-setuptools --python=python3 {{ odoo_buildout_venv_path }}"
+odoo_pip_venv_cmd: "virtualenv --python=python3 {{ odoo_pip_venv_path }}"
+
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
     - libfreetype6
-    - libpng12-0
     - zlib1g
-    - libssl1.0.0
     - libx11-6
     - libxext6
     - libxrender1
-    - libstdc++6
-    - libc6
     - libjpeg-turbo8
 
-odoo_buildout_venv_cmd: "virtualenv --no-setuptools --python=python3 {{ odoo_buildout_venv_path }}"
-odoo_pip_venv_cmd: "virtualenv --python=python3 {{ odoo_pip_venv_path }}"
-
-# Try Trusty's package if Xenial one is not found
 odoo_wkhtmltox_urls:
-    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
-    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-trusty-{{ odoo_debian_arch }}.deb
-    - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    # generic tar.gz packages
+    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz

--- a/vars/Ubuntu-16_Odoo-8.yml
+++ b/vars/Ubuntu-16_Odoo-8.yml
@@ -76,6 +76,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
@@ -92,6 +94,9 @@ odoo_wkhtmltox_depends:
 
 # Try Trusty's package if Xenial one is not found
 odoo_wkhtmltox_urls:
+    # Debian packages
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-trusty-{{ odoo_debian_arch }}.deb
     - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    # generic tar.gz packages
+    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz

--- a/vars/Ubuntu-16_Odoo-9.yml
+++ b/vars/Ubuntu-16_Odoo-9.yml
@@ -86,6 +86,8 @@ odoo_buildout_build_dependencies:
     - liblcms2-dev
     - libwebp-dev
 
+odoo_wkhtmltox_version: 0.12.1
+
 odoo_wkhtmltox_depends:
     - fontconfig
     - libfontconfig1
@@ -102,6 +104,9 @@ odoo_wkhtmltox_depends:
 
 # Try Trusty's package if Xenial one is not found
 odoo_wkhtmltox_urls:
+    # Debian packages
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-trusty-{{ odoo_debian_arch }}.deb
     - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    # generic tar.gz packages
+    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,11 +16,16 @@ odoo_pypi_packages:
 odoo_buildout_venv_cmd: "virtualenv --no-setuptools {{ odoo_buildout_venv_path }}"
 odoo_pip_venv_cmd: "virtualenv {{ odoo_pip_venv_path }}"
 
+odoo_wkhtmltox_version: 0.12.4
+
 odoo_wkhtmltox_urls:
+    # Debian packages
     - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
     - http://nightly.odoo.com/extra/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb
+    # generic tar.gz packages
+    - https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/{{ odoo_wkhtmltox_version }}/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-generic-{{ odoo_debian_arch }}.tar.xz
 
-odoo_wkhtmltox_dest: "/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}.deb"
+odoo_wkhtmltox_dest: "/root/wkhtmltox-{{ odoo_wkhtmltox_version }}_linux-{{ ansible_distribution_release }}-{{ odoo_debian_arch }}"
 
 # == NodeJS + npm ==
 odoo_nodejs_apt_package: "nodejs=0.10*"


### PR DESCRIPTION
from the generic linux package (.tar.gz) on Debian Stretch.

Still needs some local tests to check if Odoo 8 + wkhtmltopdf 0.12.4 works well.